### PR TITLE
Fix user's display name in header on user's page

### DIFF
--- a/src/resources/users.tsx
+++ b/src/resources/users.tsx
@@ -184,7 +184,7 @@ const UserTitle = () => {
       {translate("resources.users.name", {
         smart_count: 1,
       })}{" "}
-      {record ? `"${record.displayname}"` : ""}
+      {record ? ( record.displayname ? `"${record.displayname}"` : `"${record.name}"`) : ""}
     </span>
   );
 };


### PR DESCRIPTION
For example, erased users don't have display name, so header was `User "null"`. With this change, if there is no display name, the MXID will be show, e.g. `User "@user:example.com"`