### PR TITLE
Fix redirect URL after user creation

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,7 +4,7 @@ on:
     branches: [ "main" ]
 env:
   upstream_version: v0.10.3
-  etke_version: etke7
+  etke_version: etke8
   bunny_version: v0.1.0
   base_path: ./
 permissions:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The following changes are already implemented:
 * [Fix user's display name in header on user's page](https://github.com/etkecc/synapse-admin/pull/9)
 * [Fix footer overlapping content](https://github.com/Awesome-Technologies/synapse-admin/issues/574)
 * Switch from nginx to [SWS](https://static-web-server.net/) for serving the app, reducing the size of the Docker image
-by 340%
+* [Fix redirect URL after user creation](https://github.com/etkecc/synapse-admin/pull/16)
 
 _the list will be updated as new changes are added_
 

--- a/src/resources/users.tsx
+++ b/src/resources/users.tsx
@@ -204,7 +204,9 @@ const UserEditActions = () => {
 };
 
 export const UserCreate = (props: CreateProps) => (
-  <Create {...props}>
+ <Create { ...props} redirect={(resource, id, data) => {
+    return `users/${id}`;
+  }}>
     <SimpleForm>
       <TextInput source="id" autoComplete="off" validate={validateUser} />
       <TextInput source="displayname" validate={maxLength(256)} />


### PR DESCRIPTION
Related to https://github.com/etkecc/synapse-admin/pull/8

Please, fix the user's default tab after creating a new user

Steps to reproduce:
1. Open Users list, click on `Create` button (`/#/users/create`)
2. Enter user details and click on `Save` button
3. Observe broken default user tab with url encoded hash (`/#/users/%40localpart%3Aexample.com`), page reload does not help
4. Click on the `User` tab name, and observe working default user tab with **not** url encoded hash (`/#/users/@localpart:example.com`)

So, it looks like the problem is with url-encoded hash params