### PR TITLE
Display actual synapse errors

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,7 +4,7 @@ on:
     branches: [ "main" ]
 env:
   upstream_version: v0.10.3
-  etke_version: etke8
+  etke_version: etke9
   bunny_version: v0.1.0
   base_path: ./
 permissions:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The following changes are already implemented:
 * [Fix footer overlapping content](https://github.com/Awesome-Technologies/synapse-admin/issues/574)
 * Switch from nginx to [SWS](https://static-web-server.net/) for serving the app, reducing the size of the Docker image
 * [Fix redirect URL after user creation](https://github.com/etkecc/synapse-admin/pull/16)
+* [Display actual Synapse errors](https://github.com/etkecc/synapse-admin/pull/17)
 
 _the list will be updated as new changes are added_
 

--- a/src/components/error.ts
+++ b/src/components/error.ts
@@ -1,0 +1,6 @@
+export type MatrixError = {
+	errcode: string;
+	error: string;
+}
+
+export const displayError = (errcode: string, status: number, message: string) => `${errcode} (${status}): ${message}`;


### PR DESCRIPTION
Currently, Synapse-Admin shows generic errors when an error is returned from Synapse API. But Synapse Admin API uses [error format from the Matrix specification](https://spec.matrix.org/latest/client-server-api/#standard-error-response).

Please add a global error handler, that will attempt to parse the Matrix error from the response, and if failed, just return the whole response as an error message.

The format should be the following:

`<errcode> (<http status code>): <error>`, example: `M_MISSING_PARAM (400): parameter is missing`

**Example: invalid credentials**

1. Attempt to login with invalid login/password
2. See error `Authentication failed, please retry`
3. Actual error returned from API: `{"errcode":"M_FORBIDDEN","error":"Invalid username or password"}`

It should show `M_FORBIDDEN (403): Invalid username or password`