### PR TITLE
Fix required fields check on Bulk registration CSV upload, fixes #29

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The following changes are already implemented:
 * [Put the version into manifest.json](https://github.com/Awesome-Technologies/synapse-admin/issues/507) (CI only)
 * [Federation page improvements](https://github.com/Awesome-Technologies/synapse-admin/pull/583) (using theme colors)
 * [Add UI option to block deleted rooms from being rejoined](https://github.com/etkecc/synapse-admin/pull/26)
-* [Fix required fields check on Bulk registration CSV upload](https://github.com/etkecc/synapse-admin/issues/29)
+* [Fix required fields check on Bulk registration CSV upload](https://github.com/etkecc/synapse-admin/pull/32)
 
 _the list will be updated as new changes are added_
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The following changes are already implemented:
 * [Put the version into manifest.json](https://github.com/Awesome-Technologies/synapse-admin/issues/507) (CI only)
 * [Federation page improvements](https://github.com/Awesome-Technologies/synapse-admin/pull/583) (using theme colors)
 * [Add UI option to block deleted rooms from being rejoined](https://github.com/etkecc/synapse-admin/pull/26)
+* [Fix required fields check on Bulk registration CSV upload](https://github.com/etkecc/synapse-admin/issues/29)
 
 _the list will be updated as new changes are added_
 

--- a/src/components/ImportFeature.tsx
+++ b/src/components/ImportFeature.tsx
@@ -121,7 +121,11 @@ const FilePicker = () => {
 
   const verifyCsv = ({ data, meta, errors }: ParseResult<ImportLine>, { setValues, setStats, setError }) => {
     /* First, verify the presence of required fields */
-    const missingFields = expectedFields.filter(eF => meta.fields?.find(mF => eF === mF));
+    const missingFields = expectedFields.filter(eF => {
+      const result = meta.fields?.find(mF => eF === mF);
+      if (result === undefined) { return eF; } // missing field
+      return undefined; // field found
+    });
 
     if (missingFields.length > 0) {
       setError(translate("import_users.error.required_field", { field: missingFields[0] }));


### PR DESCRIPTION
The problem is originally mentioned in the https://github.com/Awesome-Technologies/synapse-admin/issues/552, but the actual reason is a bit different.

Attached file "example-bad.csv" contains a supposedly good file for import that fails either with "required field `displayname` is missing" or with "required field `id` is missing"

Attached file "example-good.csv" 
contains an unexpectedly good file for import that passes the required fields check (note that in this file `id` is renamed as `i_d` and `displayname` is renamed as `display_name`).

Nevertheless, even after that **synapse-admin does not see IDs**

[example-bad.csv](https://github.com/user-attachments/files/17024842/example-bad.csv)
[example-good.csv](https://github.com/user-attachments/files/17024843/example-good.csv)