### PR TITLE
Support authenticated media for thumbnails and other media files 

### DIFF
--- a/src/components/AvatarField.tsx
+++ b/src/components/AvatarField.tsx
@@ -1,12 +1,39 @@
 import { get } from "lodash";
 
-import { Avatar } from "@mui/material";
+import { Avatar, AvatarProps } from "@mui/material";
 import { useRecordContext } from "react-admin";
+import { useState, useEffect } from "react";
+import { fetchAuthenticatedMedia, MediaType } from "../utils/fetchMedia";
+import storage from "../storage";
 
-const AvatarField = ({ source, ...rest }) => {
-  const record = useRecordContext(rest);
-  const src = get(record, source)?.toString();
+const AvatarField = ({ source, type, ...rest }: AvatarProps & { source: string, type: MediaType, label?: string }) => {
   const { alt, classes, sizes, sx, variant } = rest;
+
+  const record = useRecordContext(rest);
+  const mxcURL = get(record, source)?.toString();
+
+  const cacheKey = `${type}_${mxcURL}`;
+  const cachedAvatar = storage.getItem(cacheKey) || "";
+  const [src, setSrc] = useState<string>(cachedAvatar);
+
+  const fetchAvatar = async (mxcURL: string) => {
+    const response = await fetchAuthenticatedMedia(mxcURL, "thumbnail");
+
+    const contentType = response.headers.get("Content-Type");
+    const arrayBuffer = await response.arrayBuffer();
+    const base64 = btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)));
+    const dataURL = `data:${contentType};base64,${base64}`;
+    setSrc(dataURL);
+    storage.setItem(cacheKey, dataURL);
+  };
+
+  useEffect(() => {
+    if (mxcURL &&!cachedAvatar) {
+      fetchAvatar(mxcURL);
+    }
+
+  }, [mxcURL, type]);
+
   return <Avatar alt={alt} classes={classes} sizes={sizes} src={src} sx={sx} variant={variant} />;
 };
 

--- a/src/resources/reports.tsx
+++ b/src/resources/reports.tsx
@@ -22,7 +22,7 @@ import {
 } from "react-admin";
 
 import { DATE_FORMAT } from "../components/date";
-import { MXCField } from "../components/media";
+import { ReportMediaContent } from "../components/media";
 
 const ReportPagination = () => <Pagination rowsPerPageOptions={[10, 25, 50, 100, 500, 1000]} />;
 
@@ -62,7 +62,7 @@ export const ReportShow = (props: ShowProps) => {
           <TextField source="event_json.content.msgtype" />
           <TextField source="event_json.content.body" />
           <TextField source="event_json.content.info.mimetype" />
-          <MXCField source="event_json.content.url" />
+          <ReportMediaContent source="event_json.content.url" />
           <TextField source="event_json.content.format" />
           <TextField source="event_json.content.formatted_body" />
           <TextField source="event_json.content.algorithm" />

--- a/src/resources/room_directory.tsx
+++ b/src/resources/room_directory.tsx
@@ -26,8 +26,8 @@ import {
   useUnselectAll,
 } from "react-admin";
 import { useMutation } from "@tanstack/react-query";
-
 import AvatarField from "../components/AvatarField";
+
 
 const RoomDirectoryPagination = () => <Pagination rowsPerPageOptions={[100, 500, 1000, 2000]} />;
 
@@ -143,8 +143,8 @@ export const RoomDirectoryList = () => (
       omit={["room_id", "canonical_alias", "topic"]}
     >
       <AvatarField
+        type="thumbnail"
         source="avatar_src"
-        sortable={false}
         sx={{ height: "40px", width: "40px" }}
         label="resources.rooms.fields.avatar"
       />

--- a/src/resources/rooms.tsx
+++ b/src/resources/rooms.tsx
@@ -47,6 +47,7 @@ import {
 } from "./room_directory";
 import { DATE_FORMAT } from "../components/date";
 import DeleteRoomButton from "../components/DeleteRoomButton";
+import AvatarField from "../components/AvatarField";
 
 const RoomPagination = () => <Pagination rowsPerPageOptions={[10, 25, 50, 100, 500, 1000]} />;
 
@@ -90,6 +91,12 @@ export const RoomShow = (props: ShowProps) => {
     <Show {...props} actions={<RoomShowActions />} title={<RoomTitle />}>
       <TabbedShowLayout>
         <Tab label="synapseadmin.rooms.tabs.basic" icon={<ViewListIcon />}>
+          <AvatarField
+            type="thumbnail"
+            source="avatar"
+            sx={{ height: "120px", width: "120px" }}
+            label="resources.rooms.fields.avatar"
+          />
           <TextField source="room_id" />
           <TextField source="name" />
           <TextField source="topic" />

--- a/src/resources/users.tsx
+++ b/src/resources/users.tsx
@@ -165,7 +165,7 @@ export const UserList = (props: ListProps) => (
     pagination={<UserPagination />}
   >
     <Datagrid rowClick={usersRowClick} bulkActionButtons={<UserBulkActionButtons />}>
-      <AvatarField source="avatar_src" sx={{ height: "40px", width: "40px" }} sortBy="avatar_url" />
+      <AvatarField type="thumbnail" source="avatar_src" sx={{ height: "40px", width: "40px" }} />
       <TextField source="id" sortBy="name" />
       <TextField source="displayname" />
       <BooleanField source="is_guest" />
@@ -323,7 +323,7 @@ export const UserEdit = (props: EditProps) => {
     <Edit {...props} title={<UserTitle />} actions={<UserEditActions />} mutationMode="pessimistic">
       <TabbedForm toolbar={<UserEditToolbar />}>
         <FormTab label={translate("resources.users.name", { smart_count: 1 })} icon={<PersonPinIcon />}>
-          <AvatarField source="avatar_src" sortable={false} sx={{ height: "120px", width: "120px" }} />
+          <AvatarField type="thumbnail" source="avatar_src" sx={{ height: "120px", width: "120px" }} />
           <BooleanInput source="avatar_erase" label="resources.users.action.erase_avatar" />
           <ImageInput
             source="avatar_file"

--- a/src/resources/users.tsx
+++ b/src/resources/users.tsx
@@ -56,6 +56,7 @@ import {
   RaRecord,
   ImageInput,
   ImageField,
+  FunctionField,
 } from "react-admin";
 import { Link } from "react-router-dom";
 
@@ -88,11 +89,6 @@ const UserListActions = () => {
       </Button>
     </TopToolbar>
   );
-};
-
-UserListActions.defaultProps = {
-  selectedIds: [],
-  onUnselectItems: () => null,
 };
 
 const UserPagination = () => <Pagination rowsPerPageOptions={[10, 25, 50, 100, 500, 1000]} />;
@@ -404,8 +400,8 @@ export const UserEdit = (props: EditProps) => {
               <DateField source="created_ts" showTime options={DATE_FORMAT} />
               <DateField source="last_access_ts" showTime options={DATE_FORMAT} />
               <NumberField source="media_length" />
-              <TextField source="media_type" />
-              <TextField source="upload_name" />
+              <TextField source="media_type" sx={{ display: "block", width: 200, wordBreak: "break-word" }} />
+              <FunctionField source="upload_name" render={record => decodeURIComponent(record.upload_name)} />
               <TextField source="quarantined_by" />
               <QuarantineMediaButton label="resources.quarantine_media.action.name" />
               <ProtectMediaButton label="resources.users_media.fields.safe_from_quarantine" />

--- a/src/synapse/authProvider.ts
+++ b/src/synapse/authProvider.ts
@@ -96,8 +96,13 @@ const authProvider: AuthProvider = {
     };
 
     if (typeof access_token === "string") {
-      await fetchUtils.fetchJson(logout_api_url, options);
-      storage.removeItem("access_token");
+      try {
+        await fetchUtils.fetchJson(logout_api_url, options);
+      } catch (err) {
+        console.log("Error logging out", err);
+      } finally {
+        storage.removeItem("access_token");
+      }
     }
   },
   // called when the API returns an error

--- a/src/synapse/synapse.ts
+++ b/src/synapse/synapse.ts
@@ -54,11 +54,6 @@ export const getSupportedLoginFlows = async baseUrl => {
   return response.json.flows;
 };
 
-export const getMediaUrl = media_id => {
-  const baseUrl = storage.getItem("base_url");
-  return `${baseUrl}/_matrix/media/v1/download/${media_id}?allow_redirect=true`;
-};
-
 /**
  * Generate a random MXID for current homeserver
  * @returns full MXID as string

--- a/src/utils/fetchMedia.ts
+++ b/src/utils/fetchMedia.ts
@@ -26,8 +26,10 @@ export const fetchAuthenticatedMedia = async (mxcUrl: string, type: MediaType): 
   let url = "";
   if (type === "thumbnail") {
     url = `${homeserver}/_matrix/client/v1/media/thumbnail/${serverName}/${mediaId}?width=24&height=24&method=scale`;
+  } else if (type === "original") {
+    url = `${homeserver}/_matrix/client/v1/media/download/${serverName}/${mediaId}`;
   } else {
-    // const url = `${homeserver}/_matrix/client/v1/media/download/${serverName}/${mediaId}`;
+    throw new Error("Invalid authenticated media type");
   }
 
   const response = await fetch(`${url}`, {

--- a/src/utils/fetchMedia.ts
+++ b/src/utils/fetchMedia.ts
@@ -1,0 +1,40 @@
+import storage from "../storage";
+
+export const getServerAndMediaIdFromMxcUrl = (mxcUrl: string): { serverName: string, mediaId: string } => {
+    const re = /^mxc:\/\/([^/]+)\/(\w+)/;
+    const ret = re.exec(mxcUrl);
+    console.log("mxcClient " + ret);
+    if (ret == null) {
+      throw new Error("Invalid mxcUrl");
+    }
+    const serverName = ret[1];
+    const mediaId = ret[2];
+    return { serverName, mediaId };
+};
+
+export type MediaType = "thumbnail" | "original";
+
+export const fetchAuthenticatedMedia = async (mxcUrl: string, type: MediaType): Promise<Response> => {
+  const homeserver = storage.getItem("base_url");
+  const accessToken = storage.getItem("access_token");
+
+  const { serverName, mediaId } = getServerAndMediaIdFromMxcUrl(mxcUrl);
+  if (!serverName || !mediaId) {
+    throw new Error("Invalid mxcUrl");
+  }
+
+  let url = "";
+  if (type === "thumbnail") {
+    url = `${homeserver}/_matrix/client/v1/media/thumbnail/${serverName}/${mediaId}?width=24&height=24&method=scale`;
+  } else {
+    // const url = `${homeserver}/_matrix/client/v1/media/download/${serverName}/${mediaId}`;
+  }
+
+  const response = await fetch(`${url}`, {
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  return response;
+};


### PR DESCRIPTION
Thumbnails are cached in the localStorage as dataURLs. If that's not efficient, caching can be removed, but in that case a bit of flickering is observed on page navigation.

Fixes #38 