### PR TITLE
Fix room state events display

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The following changes are already implemented:
 * [Custom Menu Items](https://github.com/etkecc/synapse-admin/pull/79)
 * [Add user profile to the top menu](https://github.com/etkecc/synapse-admin/pull/80)
 * [Enable visual customization](https://github.com/etkecc/synapse-admin/pull/81)
+* [Fix room state events display](https://github.com/etkecc/synapse-admin/pull/100)
 
 _the list will be updated as new changes are added_
 

--- a/src/resources/rooms.tsx
+++ b/src/resources/rooms.tsx
@@ -187,7 +187,7 @@ export const RoomShow = (props: ShowProps) => {
             <Datagrid style={{ width: "100%" }} bulkActionButtons={false}>
               <TextField source="type" sortable={false} />
               <DateField source="origin_server_ts" showTime options={DATE_FORMAT} sortable={false} />
-              <TextField source="content" sortable={false} />
+              <FunctionField source="content" sortable={false} render={record => `${JSON.stringify(record.content, null, 2)}`} />
               <ReferenceField source="sender" reference="users" sortable={false}>
                 <TextField source="id" />
               </ReferenceField>

--- a/src/synapse/authProvider.ts
+++ b/src/synapse/authProvider.ts
@@ -75,7 +75,7 @@ const authProvider: AuthProvider = {
 
       response = await fetchUtils.fetchJson(login_api_url, options);
       const json = response.json;
-      storage.setItem("home_server", accessToken ? base_url : json.home_server);
+      storage.setItem("home_server", accessToken ? json.user_id.split(":")[1] : json.home_server);
       storage.setItem("user_id", json.user_id);
       storage.setItem("access_token", accessToken ? accessToken : json.access_token);
       storage.setItem("device_id", json.device_id);


### PR DESCRIPTION
The issue originally mentioned in https://github.com/Awesome-Technologies/synapse-admin/issues/640

![image](https://github.com/user-attachments/assets/01fc4935-6048-404b-ad02-299a24ff0d75)


This PR fixes both `content` column with proper json representation, and additionally the `sender` column, removing the unnecessary requests to homeserver in case of external users and properly showing the external user ID