### PR TITLE
Allow providing login form details via GET params

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This project is built using [react-admin](https://marmelab.com/react-admin/).
   * [Changes](#changes)
   * [Development](#development)
 * [Configuration](#configuration)
+  * [Prefilling login form](#prefilling-login-form)
   * [Restricting available homeserver](#restricting-available-homeserver)
   * [Protecting appservice managed users](#protecting-appservice-managed-users)
   * [Adding custom menu items](#adding-custom-menu-items)
@@ -92,6 +93,7 @@ with a proper manifest.json generation on build)
 * [Add option to set user's rate limits](https://github.com/etkecc/synapse-admin/pull/125)
 * [Support configuration via /.well-known/matrix/client](https://github.com/etkecc/synapse-admin/pull/126)
 * [Prevent accidental user overwrites](https://github.com/etkecc/synapse-admin/pull/139)
+* [Allow providing login form details via GET params](https://github.com/etkecc/synapse-admin/pull/140)
 
 _the list will be updated as new changes are added_
 
@@ -129,6 +131,17 @@ services:
     ...
 ```
 
+### Prefilling login form
+
+You can prefill `username` and `homeserver` fields on the login page using GET parameters, example:
+
+```
+https://matrix.example.com/synapse-admin/?username=admin&server=matrix.example.com
+```
+
+That way `username` and `homeserver` fields will be pre-filled with `admin` and `https://matrix.example.com` respectively.
+
+
 ### Restricting available homeserver
 
 You can restrict the homeserver(s), so that the user can no longer define it himself.
@@ -137,7 +150,7 @@ Edit `config.json` to restrict either to a single homeserver:
 
 ```json
 {
-  "restrictBaseUrl": "https://your-matrixs-erver.example.com"
+  "restrictBaseUrl": "https://matrix.example.com"
 }
 ```
 
@@ -146,7 +159,7 @@ similar for `/.well-known/matrix/client`:
 ```json
 {
   "cc.etke.synapse-admin": {
-    "restrictBaseUrl": "https://your-matrixs-erver.example.com"
+    "restrictBaseUrl": "https://matrix.example.com"
   }
 }
 ```

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,12 @@ import { AppContext } from "./AppContext";
 import storage from "./storage";
 
 // load config.json
-let props: Config = {};
+let props: Config = {
+  restrictBaseUrl: [],
+  asManagedUsers: [],
+  supportURL: "",
+  menu: [],
+};
 try {
   const resp = await fetch("config.json");
   const configJSON = await resp.json();

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -96,6 +96,9 @@ const LoginPage = () => {
 
   const handleSubmit = auth => {
     setLoading(true);
+    const cleanUrl = window.location.href.replace(window.location.search, "");
+    window.history.replaceState({}, "", cleanUrl);
+
     login(auth).catch(error => {
       setLoading(false);
       notify(
@@ -166,6 +169,18 @@ const LoginPage = () => {
         .catch(() => setSSOBaseUrl(""));
     }, [formData.base_url, form]);
 
+    useEffect(() => {
+      const params = new URLSearchParams(window.location.search);
+      const username = params.get("username");
+      const serverURL = params.get("server");
+      if (username) {
+        form.setValue("username", username);
+      }
+      if (serverURL) {
+        form.setValue("base_url", serverURL);
+      }
+    }, [window.location.search]);
+
     return (
       <>
         <Tabs
@@ -186,10 +201,10 @@ const LoginPage = () => {
                 source="username"
                 label="ra.auth.username"
                 autoComplete="username"
-                disabled={loading || !supportPassAuth}
                 onBlur={handleUsernameChange}
                 resettable
                 validate={required()}
+                {...(loading || !supportPassAuth ? { disabled: true } : {})}
               />
             </Box>
             <Box>
@@ -198,7 +213,7 @@ const LoginPage = () => {
                 label="ra.auth.password"
                 type="password"
                 autoComplete="current-password"
-                disabled={loading || !supportPassAuth}
+                {...(loading || !supportPassAuth ? { disabled: true } : {})}
                 resettable
                 validate={required()}
               />
@@ -209,7 +224,7 @@ const LoginPage = () => {
             <TextInput
               source="accessToken"
               label="synapseadmin.auth.access_token"
-              disabled={loading}
+              {...(loading ? { disabled: true } : {})}
               resettable
               validate={required()}
             />
@@ -221,7 +236,7 @@ const LoginPage = () => {
             label="synapseadmin.auth.base_url"
             select={allowMultipleBaseUrls}
             autoComplete="url"
-            disabled={loading}
+            {...(loading ? { disabled: true } : {})}
             readOnly={allowSingleBaseUrl}
             resettable={allowAnyBaseUrl}
             validate={[required(), validateBaseUrl]}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -172,11 +172,15 @@ const LoginPage = () => {
     useEffect(() => {
       const params = new URLSearchParams(window.location.search);
       const username = params.get("username");
-      const serverURL = params.get("server");
+      let serverURL = params.get("server");
       if (username) {
         form.setValue("username", username);
       }
       if (serverURL) {
+        const isFullUrl = serverURL.match(/^(http|https):\/\//);
+        if (!isFullUrl) {
+          serverURL = `https://${serverURL}`;
+        }
         form.setValue("base_url", serverURL);
       }
     }, [window.location.search]);


### PR DESCRIPTION
`username` and `server` GET parameters on the login page will now populate the form input fields for the `Username` and `Homeserver URL` 

example usage: `http://localhost:5173/?username=admin&server=http:/localhost:8008`

Fixes #20 