### PR TITLE
Add rooms' avatars

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The following changes are already implemented:
 * 🔍 [Allow providing login form details via GET params](https://github.com/etkecc/synapse-admin/pull/140)
 * 🎨 [Add preferred theme colors to login page and footer](https://github.com/etkecc/synapse-admin/pull/155)
 * 🔰 [Add "Assign Admin" button to the rooms](https://github.com/etkecc/synapse-admin/pull/156)
+* 🖼️ [Add rooms' avatars](https://github.com/etkecc/synapse-admin/pull/158)
 
 _the list will be updated as new changes are added_
 

--- a/src/resources/rooms.tsx
+++ b/src/resources/rooms.tsx
@@ -216,7 +216,7 @@ export const RoomShow = (props: ShowProps) => {
         <Tab label="synapseadmin.rooms.tabs.members" icon={<UserIcon />} path="members">
           <MakeAdminBtn />
           <ReferenceManyField reference="room_members" target="room_id" label={false}>
-            <Datagrid style={{ width: "100%" }} rowClick={id => "/users/" + id} bulkActionButtons={false}>
+            <Datagrid sx={{ width: "100%" }} rowClick={id => "/users/" + id} bulkActionButtons={false}>
               <RaTextField source="id" sortable={false} label="resources.users.fields.id" />
               <ReferenceField
                 label="resources.users.fields.displayname"
@@ -284,7 +284,7 @@ export const RoomShow = (props: ShowProps) => {
 
         <Tab label={translate("resources.room_state.name", { smart_count: 2 })} icon={<EventIcon />} path="state">
           <ReferenceManyField reference="room_state" target="room_id" label={false}>
-            <Datagrid style={{ width: "100%" }} bulkActionButtons={false}>
+            <Datagrid sx={{ width: "100%" }} bulkActionButtons={false}>
               <RaTextField source="type" sortable={false} />
               <DateField source="origin_server_ts" showTime options={DATE_FORMAT} sortable={false} />
               <FunctionField source="content" sortable={false} render={record => `${JSON.stringify(record.content, null, 2)}`} />
@@ -305,7 +305,7 @@ export const RoomShow = (props: ShowProps) => {
             {translate("resources.rooms.helper.forward_extremities")}
           </Box>
           <ReferenceManyField reference="forward_extremities" target="room_id" label={false}>
-            <Datagrid style={{ width: "100%" }} bulkActionButtons={false}>
+            <Datagrid sx={{ width: "100%" }} bulkActionButtons={false}>
               <RaTextField source="id" sortable={false} />
               <DateField source="received_ts" showTime options={DATE_FORMAT} sortable={false} />
               <NumberField source="depth" sortable={false} />
@@ -358,6 +358,9 @@ export const RoomList = (props: ListProps) => {
         bulkActionButtons={<RoomBulkActionButtons />}
         omit={["joined_local_members", "state_events", "version", "federatable"]}
       >
+        <ReferenceField reference="rooms" source="id" label={false} link={false} sortable={false}>
+          <AvatarField source="avatar" sx={{ height: "40px", width: "40px" }} />
+        </ReferenceField>
         <BooleanField
           source="is_encrypted"
           sortBy="encryption"

--- a/src/resources/users.tsx
+++ b/src/resources/users.tsx
@@ -464,7 +464,7 @@ export const UserEdit = (props: EditProps) => {
 
         <FormTab label={translate("resources.devices.name", { smart_count: 2 })} icon={<DevicesIcon />} path="devices">
           <ReferenceManyField reference="devices" target="user_id" label={false}>
-            <Datagrid style={{ width: "100%" }} bulkActionButtons={false}>
+            <Datagrid sx={{ width: "100%" }} bulkActionButtons={false}>
               <TextField source="device_id" sortable={false} />
               <TextField source="display_name" sortable={false} />
               <TextField source="last_seen_ip" sortable={false} />
@@ -477,7 +477,7 @@ export const UserEdit = (props: EditProps) => {
         <FormTab label="resources.connections.name" icon={<SettingsInputComponentIcon />} path="connections">
           <ReferenceField reference="connections" source="id" label={false} link={false}>
             <ArrayField source="devices[].sessions[0].connections" label="resources.connections.name">
-              <Datagrid style={{ width: "100%" }} bulkActionButtons={false}>
+              <Datagrid sx={{ width: "100%" }} bulkActionButtons={false}>
                 <TextField source="ip" sortable={false} />
                 <DateField source="last_seen" showTime options={DATE_FORMAT} sortable={false} />
                 <TextField source="user_agent" sortable={false} style={{ width: "100%" }} />
@@ -499,7 +499,7 @@ export const UserEdit = (props: EditProps) => {
             perPage={50}
             sort={{ field: "created_ts", order: "DESC" }}
           >
-            <Datagrid style={{ width: "100%" }}>
+            <Datagrid sx={{ width: "100%" }}>
               <MediaIDField source="media_id" />
               <DateField source="created_ts" showTime options={DATE_FORMAT} />
               <DateField source="last_access_ts" showTime options={DATE_FORMAT} />
@@ -516,19 +516,19 @@ export const UserEdit = (props: EditProps) => {
 
         <FormTab label={translate("resources.rooms.name", { smart_count: 2 })} icon={<ViewListIcon />} path="rooms">
           <ReferenceManyField reference="joined_rooms" target="user_id" label={false}>
-            <Datagrid style={{ width: "100%" }} rowClick={id => "/rooms/" + id + "/show"} bulkActionButtons={false}>
-              <TextField source="id" sortable={false} label="resources.rooms.fields.room_id" />
-              <ReferenceField
-                label="resources.rooms.fields.name"
-                source="id"
-                reference="rooms"
-                sortable={false}
-                link=""
-              >
-                <TextField source="name" sortable={false} />
-              </ReferenceField>
-              <MakeAdminBtn />
-            </Datagrid>
+              <Datagrid sx={{ width: "100%" }} rowClick={id => "/rooms/" + id + "/show"} bulkActionButtons={false}>
+                <ReferenceField reference="rooms" source="id" label={false} link={false} sortable={false}>
+                  <AvatarField source="avatar" sx={{ height: "40px", width: "40px" }} />
+                </ReferenceField>
+                  <TextField source="id" label="resources.rooms.fields.room_id" sortable={false}/>
+                <ReferenceField reference="rooms" source="id" label="resources.rooms.fields.name" link={false} sortable={false}>
+                  <TextField source="name" />
+                </ReferenceField>
+                <ReferenceField reference="rooms" source="id" label="resources.rooms.fields.joined_members" link={false} sortable={false}>
+                  <TextField source="joined_members" sortable={false} />
+                </ReferenceField>
+                  <MakeAdminBtn />
+              </Datagrid>
           </ReferenceManyField>
         </FormTab>
 
@@ -538,7 +538,7 @@ export const UserEdit = (props: EditProps) => {
           path="pushers"
         >
           <ReferenceManyField reference="pushers" target="user_id" label={false}>
-            <Datagrid style={{ width: "100%" }} bulkActionButtons={false}>
+            <Datagrid sx={{ width: "100%" }} bulkActionButtons={false}>
               <TextField source="kind" sortable={false} />
               <TextField source="app_display_name" sortable={false} />
               <TextField source="app_id" sortable={false} />


### PR DESCRIPTION
Rooms list:
![image](https://github.com/user-attachments/assets/ced1492d-4056-43e8-b91d-dec2b6d3f45f)


User's view page:
![image](https://github.com/user-attachments/assets/e42f0947-603a-48ed-a850-14e3ae7e73c5)

---

This PR also contains fixes for tables width (e.g., in tabs of User's view page), and additional rooms' information in the Rooms tab of the User's view page