### PR TITLE
update Dockerfile to compile synapse-admin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,19 @@
+FROM node:18-alpine AS builder
+
+WORKDIR /build
+
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+
+COPY src ./src
+COPY public ./public
+COPY index.html ./index.html
+COPY vite.config.ts ./vite.config.ts
+
+RUN yarn run build --base=./
+
 FROM ghcr.io/static-web-server/static-web-server:2
 
 ENV SERVER_ROOT=/app
 
-COPY ./dist /app
+COPY --from=builder /build/dist /app

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The following changes are already implemented:
 * 🔰 [Add "Assign Admin" button to the rooms](https://github.com/etkecc/synapse-admin/pull/156)
 * 🖼️ [Add rooms' avatars](https://github.com/etkecc/synapse-admin/pull/158)
 * 🤖 [User Badges](https://github.com/etkecc/synapse-admin/pull/160)
+* 🏗️ [Dockerfile compiles binary](https://github.com/etkecc/synapse-admin/pull/179)
 
 _the list will be updated as new changes are added_
 


### PR DESCRIPTION
Was surprised to discover that the dockerfile expects the binary to have already been compiled, this brings it more in line with most apps I know of that build a fresh binary as part of the docker build step.