### PR TITLE
Support E.164-based Matrix IDs (MSC4009)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The following changes are already implemented:
 * 🤖 [User Badges](https://github.com/etkecc/synapse-admin/pull/160)
 * 🔑 [Allow prefilling any fields on the login form via GET params](https://github.com/etkecc/synapse-admin/pull/181)
 * 🖼️ [Add "Media" tab for rooms](https://github.com/etkecc/synapse-admin/pull/196)
+* ➕ [Support E.164-based Matrix IDs (MSC4009)](https://github.com/etkecc/synapse-admin/pull/214)
 
 #### exclusive for [etke.cc](https://etke.cc) customers
 

--- a/src/resources/users.tsx
+++ b/src/resources/users.tsx
@@ -189,7 +189,7 @@ export const UserList = (props: ListProps) => (
 // here only local part of user_id
 // maxLength = 255 - "@" - ":" - storage.getItem("home_server").length
 // storage.getItem("home_server").length is not valid here
-const validateUser = [required(), maxLength(253), regex(/^[a-z0-9._=\-/]+$/, "synapseadmin.users.invalid_user_id")];
+const validateUser = [required(), maxLength(253), regex(/^[a-z0-9._=\-\+/]+$/, "synapseadmin.users.invalid_user_id")];
 
 const validateAddress = [required(), maxLength(255)];
 

--- a/src/utils/mxid.ts
+++ b/src/utils/mxid.ts
@@ -41,7 +41,6 @@ export function returnMXID(input: string | Identifier): string {
   const homeserver = localStorage.getItem("home_server");
 
   // Check if the input already looks like a valid MXID (i.e., starts with "@" and contains ":")
-  const mxidPattern = /^@[^@:]+:[^@:]+$/;
   if (isMXID(input)) {
     return input as string; // Already a valid MXID
   }


### PR DESCRIPTION
[MSC4009](https://github.com/matrix-org/matrix-spec-proposals/blob/main/proposals/4009-e.164-matrix-ids.md)'s E.164-based Matrix IDs are already part of the Matrix spec [since Matrix v1.8](https://spec.matrix.org/v1.8/appendices/#user-identifiers).

This PR fixes https://github.com/Awesome-Technologies/synapse-admin/issues/648 and adds support for MXIDs like `@+15558675309:example.com`