### PR TITLE
Configurable CORS credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The following changes are already implemented:
 * [Respect base url (`BASE_PATH` / `vite build --base`) when loading `config.json`](https://github.com/etkecc/synapse-admin/pull/274)
 * [Add Users' Account Data tab](https://github.com/etkecc/synapse-admin/pull/276)
 * [Make bulk registration CSV import more user-friendly](https://github.com/etkecc/synapse-admin/pull/411)
+* [Configurable CORS Credentials](https://github.com/etkecc/synapse-admin/pull/456)
 
 #### exclusive for [etke.cc](https://etke.cc) customers
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 * [Configuration](#configuration)
   * [Prefilling login form](#prefilling-login-form)
   * [Restricting available homeserver](#restricting-available-homeserver)
+  * [Configuring CORS credentials](#configuring-cors-credentials)
   * [Protecting appservice managed users](#protecting-appservice-managed-users)
   * [Adding custom menu items](#adding-custom-menu-items)
 * [Usage](#usage)
@@ -179,6 +180,12 @@ You can prefill all fields on the login page using GET parameters.
 You can restrict the homeserver(s), so that the user can no longer define it himself.
 
 [Documentation](./docs/restrict-hs.md)
+
+### Configuring CORS credentials
+
+You can configure the CORS credentials mode for the Synapse Admin instance.
+
+[Documentation](./docs/cors-credentials.md)
 
 ### Protecting appservice managed users
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -28,6 +28,12 @@ In this case, you could provide the configuration in the `/.well-known/matrix/cl
   The homeserver URL should be the _actual_ homeserver URL, and not the delegated one.
   Example: `https://matrix.example.com` or `https://synapse.example.net`
   [More details](restrict-hs.md)
+* `corsCredentials` - configure the CORS credentials for the Synapse Admin instance.
+  It accepts the following values:
+  * `same-origin` (default): Cookies will be sent only if the request is made from the same origin as the server.
+  * `include`: Cookies will be sent regardless of the origin of the request.
+  * `omit`: Cookies will not be sent with the request.
+  [More details](cors-credentials.md)
 * `asManagedUsers` - protect system user accounts managed by appservices (such as bridges) / system (such as bots) from accidental changes.
   By defining a list of MXID regex patterns, you can protect these accounts from accidental changes.
   Example: `^@baibot:example\\.com$`, `^@slackbot:example\\.com$`, `^@slack_[a-zA-Z0-9\\-]+:example\\.com$`, `^@telegrambot:example\\.com$`, `^@telegram_[a-zA-Z0-9]+:example\\.com$`

--- a/docs/cors-credentials.md
+++ b/docs/cors-credentials.md
@@ -1,0 +1,35 @@
+# CORS Credentials
+
+If you'd like to use cookie-based authentication
+(for example, [ForwardAuth with Authelia](https://github.com/Awesome-Technologies/synapse-admin/issues/655)),
+you can configure the `corsCredentials` option in the `config.json` file or in the `/.well-known/matrix/client` file.
+
+## Configuration
+
+> [Documentation on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#including_credentials)
+
+The `corsCredentials` option accepts the following values:
+
+* `same-origin` (default): Cookies will be sent only if the request is made from the same origin as the server.
+* `include`: Cookies will be sent regardless of the origin of the request.
+* `omit`: Cookies will not be sent with the request.
+
+[Configuration options](config.md)
+
+### config.json
+
+```json
+{
+  "corsCredentials": "include"
+}
+```
+
+### `/.well-known/matrix/client`
+
+```json
+{
+  "cc.etke.synapse-admin": {
+    "corsCredentials": "include"
+  }
+}
+```

--- a/src/synapse/authProvider.test.ts
+++ b/src/synapse/authProvider.test.ts
@@ -35,6 +35,7 @@ describe("authProvider", () => {
           Accept: "application/json",
           "Content-Type": "application/json",
         }),
+        credentials: "same-origin",
         method: "POST",
       });
       expect(localStorage.getItem("base_url")).toEqual("http://example.com");
@@ -66,6 +67,7 @@ describe("authProvider", () => {
         Accept: "application/json",
         "Content-Type": "application/json",
       }),
+      credentials: "same-origin",
       method: "POST",
     });
     expect(localStorage.getItem("base_url")).toEqual("https://example.com");
@@ -88,6 +90,7 @@ describe("authProvider", () => {
           Authorization: "Bearer foo",
         }),
         method: "POST",
+        credentials: "same-origin",
         user: { authenticated: true, token: "Bearer foo" },
       });
       expect(localStorage.getItem("access_token")).toBeNull();

--- a/src/synapse/authProvider.ts
+++ b/src/synapse/authProvider.ts
@@ -23,6 +23,7 @@ const authProvider: AuthProvider = {
     console.log("login ");
     let options: Options = {
       method: "POST",
+      credentials: GetConfig().corsCredentials,
       body: JSON.stringify(
         Object.assign(
           {
@@ -151,6 +152,7 @@ const authProvider: AuthProvider = {
 
     const options: Options = {
       method: "POST",
+      credentials: GetConfig().corsCredentials,
       user: {
         authenticated: true,
         token: `Bearer ${access_token}`,

--- a/src/synapse/dataProvider.ts
+++ b/src/synapse/dataProvider.ts
@@ -14,6 +14,7 @@ import {
 } from "react-admin";
 
 import { returnMXID } from "../utils/mxid";
+import { GetConfig } from "../utils/config";
 import { MatrixError, displayError } from "../utils/error";
 
 const CACHED_MANY_REF: Record<string, any> = {};
@@ -22,6 +23,7 @@ const CACHED_MANY_REF: Record<string, any> = {};
 const jsonClient = async (url: string, options: Options = {}) => {
   const token = localStorage.getItem("access_token");
   console.log("httpClient " + url);
+  options.credentials = GetConfig().corsCredentials;
   if (token !== null) {
     options.user = {
       authenticated: true,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,5 +1,6 @@
 export interface Config {
   restrictBaseUrl: string | string[];
+  corsCredentials: string;
   asManagedUsers: RegExp[];
   menu: MenuItem[];
   etkeccAdmin?: string;
@@ -16,6 +17,7 @@ export const WellKnownKey = "cc.etke.synapse-admin";
 // current configuration
 let config: Config = {
   restrictBaseUrl: "",
+  corsCredentials: "same-origin",
   asManagedUsers: [],
   menu: [],
   etkeccAdmin: ""
@@ -67,6 +69,10 @@ export const FetchConfig = async () => {
 export const LoadConfig = (context: any) => {
   if (context?.restrictBaseUrl) {
     config.restrictBaseUrl = context.restrictBaseUrl as string | string[];
+  }
+
+  if (context?.corsCredentials) {
+    config.corsCredentials = context.corsCredentials;
   }
 
   if (context?.asManagedUsers) {


### PR DESCRIPTION
Allow configuration of fetch's `credentials` for cases when you need to work with cookies, e.g. in the case of ForwardAuth.

The issue was originally raised in https://github.com/Awesome-Technologies/synapse-admin/issues/655