### PR TITLE
fix running on ipv4-only systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ You have three options:
 
   > note: if you're building on an architecture other than amd64 (for example a raspberry pi), make sure to define a maximum ram for node. otherwise the build will fail.
 
+  > note: if you're running on a ipv4-only system, make sure to set `SERVER_HOST=0.0.0.0` env var. Otherwise synapse-admin will not be able to start.
+
   ```yml
   services:
     synapse-admin:


### PR DESCRIPTION
This simple fix makes running this fork of synapse-admin on ipv4-only systems possible. 
Currently, running synapse-admin on non-ipv6 systems throws the following error:
```
synapse-admin  | 2025-11-20T15:42:48.214133Z ERROR static_web_server::server: server failed to start up: failed to bind to [::]:80 address
synapse-admin  | 
synapse-admin  | Caused by:
synapse-admin  |     Address family not supported by protocol (os error 97)
```
As mentioned in this [issue in static-web-server](https://github.com/static-web-server/static-web-server/issues/134) passing the environment variable `SERVER_HOST=0.0.0.0` overrides the default (`SERVER_HOST=[::]`) and therefore fixes this issue :)
 