### PR TITLE
Fixed eslint-plugin-import peer dependency error

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "https://liberapay.com/etkecc"
   ],
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.39.3",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -43,7 +43,7 @@
     "@typescript-eslint/parser": "^8.59.1",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.5",
-    "eslint": "^10.2.1",
+    "eslint": "^9.39.3",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",


### PR DESCRIPTION
As described in #1169, currently `npm i` fails due to a peer dependency error.

The `eslint-plugin-import` package doesn't supports v10 versions of `eslint` yet, thus I've downgraded `eslint` to the latest v9 version (`9.39.3`) for now, so contributors can run `npm i` without the `--legacy-peer-deps` flag and start Ketesa locally.

Resolves #1169