### PR TITLE
Fix client side filtering for Exclude system users not working

### DIFF
--- a/src/providers/data/index.ts
+++ b/src/providers/data/index.ts
@@ -287,7 +287,7 @@ const baseDataProvider: SynapseDataProvider = {
 
     // Allow resource to override getList entirely (e.g. MAS users Synapse-first sort)
     // Skip when reverse search or system_users scan is active — handled below for both modes.
-    if (!isReverseSearch && !system_users && res.getList) {
+    if (!isReverseSearch && system_users == null && res.getList) {
       const result = await res.getList({
         pagination: params.pagination as PaginationPayload,
         sort: params.sort as SortPayload,


### PR DESCRIPTION
The condition needs to check for null instead of false, otherwise it causes early bailout for the non-system users case and the client side filtering never happens.