### PR TITLE
Remove trailing slash on media download endpoint

### DIFF
--- a/src/utils/fetchMedia.test.ts
+++ b/src/utils/fetchMedia.test.ts
@@ -52,7 +52,7 @@ describe("fetchAuthenticatedMedia", () => {
     await fetchAuthenticatedMedia("mxc://matrix.example/media123", "original");
 
     expect(global.fetch).toHaveBeenCalledWith(
-      "https://hs.example/_matrix/client/v1/media/download/matrix.example/media123/?admin_unsafely_bypass_quarantine=true",
+      "https://hs.example/_matrix/client/v1/media/download/matrix.example/media123?admin_unsafely_bypass_quarantine=true",
       {
         headers: {
           authorization: "Bearer secret-token",

--- a/src/utils/fetchMedia.ts
+++ b/src/utils/fetchMedia.ts
@@ -30,7 +30,7 @@ export const fetchAuthenticatedMedia = async (mxcUrl: string, type: MediaType): 
     // ref: https://spec.matrix.org/latest/client-server-api/#thumbnails
     url = `${homeserver}/_matrix/client/v1/media/thumbnail/${serverName}/${mediaId}?width=320&height=240&method=scale`;
   } else if (type === "original") {
-    url = `${homeserver}/_matrix/client/v1/media/download/${serverName}/${mediaId}/?admin_unsafely_bypass_quarantine=true`;
+    url = `${homeserver}/_matrix/client/v1/media/download/${serverName}/${mediaId}?admin_unsafely_bypass_quarantine=true`;
   } else {
     throw new Error("Invalid authenticated media type");
   }


### PR DESCRIPTION
The spec doesn't allow a trailing slash there, synapse ignores it but it breaks on tuwunel